### PR TITLE
in 2.x typecast method doesn't overwrite typecast property

### DIFF
--- a/cosmoz-page-router-behavior-utilities.js
+++ b/cosmoz-page-router-behavior-utilities.js
@@ -197,7 +197,7 @@
 			// parse the arguments into unescaped strings, numbers, or booleans
 				for (arg in args) {
 					if (args.hasOwnProperty(arg)) {
-						args[arg] = this.typecast(args[arg]);
+						args[arg] = this._typecast(args[arg]);
 					}
 				}
 			}
@@ -206,7 +206,7 @@
 		},
 
 		// typecast(value) - Typecast the string value to an unescaped string, number, or boolean
-		typecast: function (value) {
+		_typecast: function (value) {
 			// bool
 			if (value === 'true') {
 				return true;

--- a/cosmoz-page-router.js
+++ b/cosmoz-page-router.js
@@ -81,6 +81,10 @@
 
 		/**
 		* Utility function that fires an event from a polymer element and return false if preventDefault has been called on the event.
+		* @param {String} type The event type
+		* @param {Object} detail The event detail
+		* @param {HTMLElement} node The node that will fire the event
+		* @param {Boolean} bubbles True if event should bubble
 		* @return {Boolean} `true` = continue, `false` = prevent further actions
 		*/
 		_fireEvent: function (type, detail, node, bubbles) {


### PR DESCRIPTION
Renamed typecast method to _typecast
Typecast property is kept