### PR TITLE
Search for element in window.customElements also

### DIFF
--- a/cosmoz-page-router.js
+++ b/cosmoz-page-router.js
@@ -373,9 +373,10 @@
 		},
 
 		_hasCustomElement: function (elementName) {
+			const customElements = window.customElements;
 			return Polymer.telemetry.registrations.some(function (element) {
 				return element.is === elementName;
-			});
+			}) || customElements && customElements.get(elementName) != null;
 		},
 
 		_activateImport: function (route, url, eventDetail, importLink) {


### PR DESCRIPTION
In 2.x telemetry works a bit different.  It seems a item is added there when first instantiated.
See also Polymer/polymer#2730