### PR TITLE
Import custom elements without searching for a dom-module

### DIFF
--- a/cosmoz-page-route.js
+++ b/cosmoz-page-route.js
@@ -51,6 +51,11 @@
 
 			templateInstance: {
 				type: Object
+			},
+
+			hasCustomElement: {
+				type: Boolean,
+				value: false
 			}
 		},
 

--- a/cosmoz-page-router.js
+++ b/cosmoz-page-router.js
@@ -406,6 +406,11 @@
 			// make sure the user didn't navigate to a different route while it loaded
 			if (route === this._loadingRoute) {
 
+				if (route.hasCustomElement && this._hasCustomElement(route.templateId)) {
+					this._activateCustomElement(route, url, eventDetail);
+					return;
+				}
+
 				var template = importLink.import.getElementById(route.templateId);
 
 				if (!template) {


### PR DESCRIPTION
Import custom elements without searching for a dom-module.

Fixes #28