### PR TITLE
Add iron-selected class to slot 

### DIFF
--- a/cosmoz-page-router.html
+++ b/cosmoz-page-router.html
@@ -85,7 +85,8 @@ Will otherwise be fired when activated for persisted views.
 				id="routes"
 				attr-for-selected="path"
 				on-neon-animation-finish="_onNeonAnimationFinish">
-			<slot></slot>
+			<!-- TODO: Remove this when neon-animated-pages is fixed or dropped-->
+			<slot class="iron-selected"></slot>
 		</neon-animated-pages>
 	</template>
   <script type="text/javascript" src="cosmoz-page-router.js"></script>


### PR DESCRIPTION
Add iron-selected class to slot  to prevent it from getting display none in Safari 11 and/or iOS