### PR TITLE
38 - Update to Polymer 2.x - part 3

### DIFF
--- a/cosmoz-page-route.js
+++ b/cosmoz-page-route.js
@@ -65,13 +65,6 @@
 			};
 		}
 
-		static get behaviors() {
-			return [
-				Polymer.IronResizableBehavior,
-				Polymer.NeonAnimatableBehavior
-			];
-		}
-
 		deactivate() {
 			let node,
 				nodeToRemove;

--- a/cosmoz-page-route.js
+++ b/cosmoz-page-route.js
@@ -2,67 +2,75 @@
 (function () {
 	'use strict';
 
-	Polymer({
-		is: 'cosmoz-page-route',
-		properties: {
-			active: Boolean,
-			animationConfig: {
-				value() {
-					return {
-						entry: {
-							name: 'fade-in-animation',
-							node: this,
-							timing: {
-								duration: 150
+	class CosmozPageRoute extends Polymer.mixinBehaviors([Polymer.IronResizableBehavior, Polymer.NeonAnimatableBehavior], Polymer.Element) {
+
+		static get is() {
+			return 'cosmoz-page-route';
+		}
+
+		static get properties() {
+			return {
+				active: Boolean,
+				animationConfig: {
+					value() {
+						return {
+							entry: {
+								name: 'fade-in-animation',
+								node: this,
+								timing: {
+									duration: 150
+								}
+							},
+							exit: {
+								name: 'fade-out-animation',
+								node: this,
+								timing: {
+									duration: 150
+								}
 							}
-						},
-						exit: {
-							name: 'fade-out-animation',
-							node: this,
-							timing: {
-								duration: 150
-							}
-						}
-					};
+						};
+					}
+				},
+
+				import: {
+					type: String,
+				},
+
+				imported: {
+					type: Boolean,
+					value: false
+				},
+
+				path: {
+					type: String,
+				},
+
+				persist: {
+					type: Boolean,
+					value: false
+				},
+
+				templateId: {
+					type: String,
+				},
+
+				templateInstance: {
+					type: Object
+				},
+
+				hasCustomElement: {
+					type: Boolean,
+					value: false
 				}
-			},
+			};
+		}
 
-			import: {
-				type: String,
-			},
-
-			imported: {
-				type: Boolean,
-				value: false
-			},
-
-			path: {
-				type: String,
-			},
-
-			persist: {
-				type: Boolean,
-				value: false
-			},
-
-			templateId: {
-				type: String,
-			},
-
-			templateInstance: {
-				type: Object
-			},
-
-			hasCustomElement: {
-				type: Boolean,
-				value: false
-			}
-		},
-
-		behaviors: [
-			Polymer.IronResizableBehavior,
-			Polymer.NeonAnimatableBehavior
-		],
+		static get behaviors() {
+			return [
+				Polymer.IronResizableBehavior,
+				Polymer.NeonAnimatableBehavior
+			];
+		}
 
 		deactivate() {
 			let node,
@@ -79,7 +87,9 @@
 				this.templateInstance = null;
 			}
 		}
-	});
+	}
+
+	customElements.define(CosmozPageRoute.is, CosmozPageRoute);
 
 	/**
 	 * Fired when the template node has been imported and mixed in with its template object.

--- a/cosmoz-page-router.html
+++ b/cosmoz-page-router.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../neon-animation/animations/fade-out-animation.html">
 <link rel="import" href="detect-import-node-bug.html">
 <link rel="import" href="cosmoz-page-route.html">
+<link rel="import" href="../polymer/lib/utils/async.html">
 
 <!--
 `<cosmoz-page-router>` is a template based client-side routing solution

--- a/cosmoz-page-router.js
+++ b/cosmoz-page-router.js
@@ -88,11 +88,16 @@
 		* @return {Boolean} `true` = continue, `false` = prevent further actions
 		*/
 		_fireEvent(type, detail, node, bubbles) {
-			return !this.fire(type, detail, {
-				bubbles: !!bubbles,
-				cancelable: true,
-				node: node || this
-			}).defaultPrevented;
+			return !this.dispatchEvent(new CustomEvent(
+				type,
+				{
+					bubbles: !!bubbles,
+					cancelable: true,
+					composed: true,
+					detail,
+					node: node || this
+				}
+			)).defaultPrevented;
 		},
 
 		/**
@@ -137,12 +142,16 @@
 			}
 
 			// dispatch a popstate event
-			this.fire('popstate', {
-				state: {}
-			}, {
-				node: window,
-				bubbles: false
-			});
+			this.dispatchEvent(new CustomEvent(
+				'popstate',
+				{
+					bubbles: false,
+					composed: true,
+					detail: {
+						state: {}
+					}
+				}
+			));
 		},
 
 		// scroll to the element with id="hash" or name="hash"

--- a/cosmoz-page-router.js
+++ b/cosmoz-page-router.js
@@ -115,7 +115,7 @@
 			this._routesInError = {};
 			this._importLinksListeners = {};
 			if (!this.manualInit) {
-				this.async(this.initialize);
+				Polymer.Async.microTask.run(() => this.initialize);
 			}
 		},
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -44,16 +44,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 			(function () {
 				'use strict';
 
-				window.addEventListener('WebComponentsReady', function () {
-					var pageRouter = document.querySelector('cosmoz-page-router');
+				window.addEventListener('WebComponentsReady', () => {
+					let pageRouter = document.querySelector('cosmoz-page-router');
 
-					pageRouter.addEventListener('template-created', function (event) {
+					pageRouter.addEventListener('template-created',  () => {
 						console.log('test-cz-page-router template-created');
 					});
-					pageRouter.addEventListener('template-ready', function (event) {
+					pageRouter.addEventListener('template-ready', () => {
 						console.log('test-cz-page-router template-ready');
 					});
-					pageRouter.addEventListener('template-activate', function (event) {
+					pageRouter.addEventListener('template-activate', () => {
 						console.log('test-cz-page-router template-activate');
 					});
 

--- a/demo/issue-36.html
+++ b/demo/issue-36.html
@@ -56,9 +56,8 @@
 			(function () {
 				'use strict';
 
-				window.addEventListener('WebComponentsReady', function () {
-					var pageRouter = document.querySelector('cosmoz-page-router');
-					pageRouter.initialize();
+				window.addEventListener('WebComponentsReady', () => {
+					document.querySelector('cosmoz-page-router').initialize();
 				});
 			}());
 		</script>

--- a/demo/location.html
+++ b/demo/location.html
@@ -80,7 +80,7 @@
 	(function () {
 		window.addEventListener('WebComponentsReady', function () {
 			(function () {
-				var basic = document.getElementById('basic');
+				let basic = document.getElementById('basic');
 				basic = !basic.set ? basic.firstElementChild : basic;
 				basic._computeRouteUrl = function (hashParam, queryParam) {
 					let route = this.$.location.getRoute();

--- a/test/basic.html
+++ b/test/basic.html
@@ -11,6 +11,8 @@
 
 	<link rel="import" href="../../test-fixture/test-fixture.html">
 	<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+	<link rel="import" href="/../../polymer/lib/utils/async.html">
+
 	<link rel="import" href="../cosmoz-page-router.html">
 </head>
 <body>
@@ -42,11 +44,9 @@
 
 			setup(done => {
 				router = fixture('basic');
-				Polymer.Base.async(() => {
-					done();
-				});
+				Polymer.Async.microTask.run(() => done());
 			});
-/*
+
 			test('instantiates a cosmoz-page-router element', () => {
 				assert.equal(router.is, 'cosmoz-page-router');
 			});
@@ -101,7 +101,7 @@
 					console.log('stateChange');
 				};
 				router.refresh(true);
-				Polymer.Base.async(() => {
+				setTimeout(() => {
 					assert.isNull(router._previousUrl);
 					done();
 				}, 100);
@@ -122,7 +122,6 @@
 				assert.calledOnce(spy);
 				spy.restore();
 			});
-*/
 		});
 
 		suite('<cosmoz-page-router mode="hashbang">', () => {
@@ -131,9 +130,7 @@
 
 			setup(done => {
 				router = fixture('hashbang');
-				Polymer.Base.async(() => {
-					done();
-				});
+				Polymer.Async.microTask.run(() => done());
 			});
 
 			test('instantiates a cosmoz-page-router element', () => {

--- a/test/basic.html
+++ b/test/basic.html
@@ -47,10 +47,6 @@
 				Polymer.Async.microTask.run(() => done());
 			});
 
-			test('instantiates a cosmoz-page-router element', () => {
-				assert.equal(router.is, 'cosmoz-page-router');
-			});
-
 			test('initialize verifies if already initialized', done => {
 				const spy = sinon.spy(router, '_stateChange');
 				router.initialize();
@@ -61,7 +57,6 @@
 
 			test('addRoute returns new route', () => {
 				const route = router.addRoute(data);
-				assert.equal(route.is, 'cosmoz-page-route');
 				assert.equal(route.path, '/view3');
 				assert.equal(route.templateId, 'view3');
 			});
@@ -133,10 +128,6 @@
 				Polymer.Async.microTask.run(() => done());
 			});
 
-			test('instantiates a cosmoz-page-router element', () => {
-				assert.equal(router.is, 'cosmoz-page-router');
-			});
-
 			test('_hasCustomElement returns true for cozmoz-page-router', done => {
 				assert.isTrue(router._hasCustomElement('cosmoz-page-route'));
 				assert.isTrue(router._hasCustomElement('cosmoz-page-router'));
@@ -145,7 +136,6 @@
 
 			test('addRoute returns new route', () => {
 				const route = router.addRoute(data);
-				assert.equal(route.is, 'cosmoz-page-route');
 				assert.equal(route.path, '/view2');
 				assert.equal(route.templateId, 'view2');
 				route.deactivate();

--- a/test/index.html
+++ b/test/index.html
@@ -7,12 +7,12 @@
 </head>
 <body>
 	<script>
-		var pages = [
+		const pages = [
 				'basic.html',
 				'location.html'
 			],
-			suites = [],
-			i;
+			suites = [];
+		let i;
 
 		for (i = 0; i < pages.length; i++) {
 			suites.push(pages[i] + '?dom=shadow');

--- a/test/location.html
+++ b/test/location.html
@@ -11,6 +11,7 @@
 
 	<link rel="import" href="../../test-fixture/test-fixture.html">
 	<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+	<link rel="import" href="/../../polymer/lib/utils/async.html">
 	<link rel="import" href="../cosmoz-page-location.html">
 </head>
 <body>
@@ -26,9 +27,7 @@
 			let location;
 			setup(done => {
 				location = fixture('basic');
-				Polymer.Base.async(() => {
-					done();
-				});
+				Polymer.Async.microTask.run(() => done());
 			});
 
 			test('instantiates a cosmoz-page-location element', () => {
@@ -87,9 +86,7 @@
 
 			setup(done => {
 				location = fixture('basic');
-				Polymer.Base.async(function () {
-					done();
-				});
+				Polymer.Async.microTask.run(() => done());
 			});
 
 			Object.keys(tests).forEach((key, index) => {


### PR DESCRIPTION
Update to Polymer 2.x - part 3.

* Replacing var with const and let.
* Re-enabling tests.
* Replacing async with Async and timeouts.
* Replacing fire with dispatchEvent.
* Updating function declarations to arrow type.
* Updating parts of the code base to ES6 class syntax.
* Removing is checks from tests.

Issue is #38.