### PR TITLE
Enable importing JS-based views as ES modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "eslint.autoFixOnSave": true,
+    "eslint.validate": [
+        { "language": "javascript", "autoFix": true }
+    ]
+}

--- a/cosmoz-page-router.js
+++ b/cosmoz-page-router.js
@@ -453,9 +453,11 @@ class CosmozPageRouter extends PolymerElement {
 		let importLink;
 		const
 			importUri = route.import,
-			importLoadedCallback =	() => {
-				importLink.loaded = true;
-				this._removeImportLinkListeners(importLink);
+			importLoadedCallback = () => {
+				if (importLink != null) {
+					importLink.loaded = true;
+					this._removeImportLinkListeners(importLink);
+				}
 				route.imported = true;
 				this._activateImport(route, url, eventDetail, importLink);
 			},
@@ -472,6 +474,11 @@ class CosmozPageRouter extends PolymerElement {
 				this._fireEvent('import-error', importErrorEvent);
 			};
 
+		if (importUri.endsWith('.js')) {
+			this._fireEvent('route-loading', eventDetail);
+			import(importUri).catch(importErrorCallback).then(importLoadedCallback);
+			return;
+		}
 		if (this._importedUris === null) {
 			this._importedUris = {};
 		}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	},
 	"scripts": {
 		"analyze": "polymer analyze --input cosmoz-*.js  > analysis.json",
-		"lint": "eslint --cache --ext .js,.html . && polymer lint cosmoz-*.js",
+		"lint": "eslint --cache cosmoz-*.js && polymer lint cosmoz-*.js",
 		"start": "polymer serve -o",
 		"test": "polymer test"
 	},
@@ -43,7 +43,6 @@
 		"babel-eslint": "^10.0.2",
 		"chai": "^4.2.0",
 		"eslint": "^5.9.0",
-		"eslint-plugin-html": "^5.0.0",
 		"eslint-plugin-import": "^2.17.3",
 		"eslint-plugin-mocha": "^5.2.0",
 		"mocha": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"babel-eslint": "^10.0.2",
 		"chai": "^4.2.0",
 		"eslint": "^5.9.0",
+		"eslint-plugin-html": "^5.0.0",
 		"eslint-plugin-import": "^2.17.3",
 		"eslint-plugin-mocha": "^5.2.0",
 		"mocha": "^5.0.0",

--- a/polymer.json
+++ b/polymer.json
@@ -1,6 +1,9 @@
 {
 	"npm": true,
 	"lint": {
-		"rules": ["polymer-3"]
+		"rules": ["polymer-3"],
+		"ignoreWarnings": [
+			"non-literal-import"
+		]
 	}
 }


### PR DESCRIPTION
- Import ends with .JS use import() instead of link rel="import"
- Slim linting step

Makes it possible to switch to JS-bundles which would fix https://github.com/Neovici/cosmoz-frontend/issues/1249

ping @cristinecula 

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>