### PR TITLE
(patch) modulizer erroneously escaped `attr$=` to `attr\$=`

### DIFF
--- a/demo/location.html
+++ b/demo/location.html
@@ -63,7 +63,7 @@
 					<p>
 						<label>app param</label>
 						<input value="{{ appParam::input }}">
-						<a href\$="{{ _computeAppUrl(appParam) }}">{{ _computeAppUrl(appParam) }}</a>
+						<a href$="{{ _computeAppUrl(appParam) }}">{{ _computeAppUrl(appParam) }}</a>
 					</p>
 				</template>
 			</dom-bind>


### PR DESCRIPTION
https://github.com/Neovici/cosmoz-frontend/issues/1314