### PR TITLE
fix: handles encoded `#` in hash

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -1,5 +1,9 @@
 export const hashbang = rule => url => {
 	const origin = document.location.origin,
+		/* Chrome on iOS bug encodes second `#` in url as `%23`
+		 * https://github.com/Neovici/cosmoz-frontend/issues/1524
+		 * https://github.com/angular/angular.js/issues/7699
+		*/
 		hash = new URL(url, origin).hash.replace(/^#!?/iu, '').replace('%23', '#'),
 		hashUrl = new URL(hash, origin),
 		result = hashUrl.pathname.match(rule);

--- a/lib/match.js
+++ b/lib/match.js
@@ -1,6 +1,7 @@
 export const hashbang = rule => url => {
 	const origin = document.location.origin,
-		hashUrl = new URL(new URL(url, origin).hash.replace(/^#!?/iu, ''), origin),
+		hash = new URL(url, origin).hash.replace(/^#!?/iu, '').replace('%23', '#'),
+		hashUrl = new URL(hash, origin),
 		result = hashUrl.pathname.match(rule);
 	return result && {
 		result,


### PR DESCRIPTION
Fixes Chrome on iOS bug when second `#` in url is encoded as `%23`
